### PR TITLE
Load micro-frontend styles

### DIFF
--- a/apps/trending/src/main.jsx
+++ b/apps/trending/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client'; 
+import ReactDOM from 'react-dom/client';
 import Trending from './components/Trending';
+import './style.css';
 
 export function mount(el) {
   const root = ReactDOM.createRoot(el); 

--- a/apps/trending/src/style.css
+++ b/apps/trending/src/style.css
@@ -1,0 +1,11 @@
+.trending {
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+.trending ul {
+  list-style: none;
+  padding: 0;
+}
+.trending li {
+  margin-bottom: 0.5rem;
+}

--- a/host/main.js
+++ b/host/main.js
@@ -1,5 +1,7 @@
 import { mount as mountHeader } from '../apps/header/dist/header.js';
 import { mount as mountTrending } from '../apps/trending/dist/trending.js';
+import '../apps/header/dist/style.css';
+import '../apps/trending/dist/style.css';
 
 mountHeader(document.querySelector('#header'));
 mountTrending(document.querySelector('#trending'));


### PR DESCRIPTION
## Summary
- import each app's css into the host
- add a simple stylesheet for the Trending app
- load that stylesheet when the React app mounts

## Testing
- `npm -v`
- `npm run lint -ws` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a283d5674832cb3ebe14d677b4c28