### PR TITLE
docs: clarify running npm scripts per package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository is linked to this article [MFE](https://dev.to/mairouche/setup-a
 The `host/` folder contains the Micro Frontend Shell with Vite Vanilla.
 The `apps/` folder contains the microfrotends modules (angular is not working at this stage but will be added in a later commit).
 
+Each of these folders is a standalone npm package with its own `package.json`. The repository root does not contain a `package.json`, so running npm commands from the root directory will fail. Make sure to run all npm scripts inside the relevant package folder (`apps/header`, `apps/trending` or `host`).
+
 To start the application, follow the steps.
 
 ## Step 1 : Build the Vue Header micro frontend


### PR DESCRIPTION
## Summary
- explain that each folder is an npm package
- point out that there is no root `package.json` and running npm commands from root will fail

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a2c181934832cb5b98ee552a37865