### PR TITLE
Add Node notifications service

### DIFF
--- a/services/node-notifications/Dockerfile
+++ b/services/node-notifications/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3001
+CMD ["node", "src/index.js"]

--- a/services/node-notifications/README.md
+++ b/services/node-notifications/README.md
@@ -1,0 +1,29 @@
+# Node Notifications Service
+
+This service provides simple endpoints to send email or push notifications. It runs an Express server on port **3001**.
+
+## Setup
+
+Install dependencies and start the server:
+
+```bash
+cd services/node-notifications
+npm install
+npm start
+```
+
+The server will listen on `http://localhost:3001`.
+
+## Docker
+
+Build and run the container:
+
+```bash
+docker build -t node-notifications .
+docker run -p 3001:3001 node-notifications
+```
+
+## Endpoints
+
+- `POST /email` – simulate sending an email notification.
+- `POST /push` – simulate sending a push notification.

--- a/services/node-notifications/package.json
+++ b/services/node-notifications/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "node-notifications",
+  "version": "1.0.0",
+  "description": "Notification service for micro frontend demo",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/node-notifications/src/index.js
+++ b/services/node-notifications/src/index.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.post('/email', (req, res) => {
+  console.log('Email notification:', req.body);
+  res.json({ status: 'sent' });
+});
+
+app.post('/push', (req, res) => {
+  console.log('Push notification:', req.body);
+  res.json({ status: 'sent' });
+});
+
+app.get('/', (req, res) => {
+  res.send('Notification service running');
+});
+
+app.listen(PORT, () => {
+  console.log(`Notification service listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement a simple Express notification service
- include Dockerfile for Node 22 Alpine
- document setup, Docker usage, and endpoints

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684c2e91edac832c8ab688d0cf5d0f87