### PR TITLE
Add Python forecast service

### DIFF
--- a/services/python-forecast/Dockerfile
+++ b/services/python-forecast/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Poetry
+RUN pip install --no-cache-dir poetry
+
+COPY pyproject.toml poetry.lock* /app/
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-dev --no-interaction --no-ansi
+
+COPY src ./src
+
+EXPOSE 3002
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "3002"]

--- a/services/python-forecast/README.md
+++ b/services/python-forecast/README.md
@@ -1,0 +1,29 @@
+# Python Forecast Service
+
+This service exposes a small FastAPI application that returns simple weather forecasts. It listens on **port 3002**.
+
+## Setup
+
+Install dependencies and start the server:
+
+```bash
+cd services/python-forecast
+poetry install
+poetry run uvicorn src.main:app --port 3002 --reload
+```
+
+The server will be available at `http://localhost:3002`.
+
+## Docker
+
+Build and run the container:
+
+```bash
+docker build -t python-forecast .
+docker run -p 3002:3002 python-forecast
+```
+
+## Endpoints
+
+- `GET /health` – basic health check.
+- `POST /forecast` – return a simple forecast for the requested location.

--- a/services/python-forecast/pyproject.toml
+++ b/services/python-forecast/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "python-forecast"
+version = "0.1.0"
+description = "FastAPI service for weather/ML forecasts"
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.111.0"
+uvicorn = {extras = ["standard"], version = "^0.29.0"}
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/services/python-forecast/src/main.py
+++ b/services/python-forecast/src/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Forecast Service")
+
+class ForecastRequest(BaseModel):
+    location: str
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.post("/forecast")
+def forecast(data: ForecastRequest):
+    # Placeholder logic for demonstration purposes
+    return {"location": data.location, "forecast": "sunny"}
+


### PR DESCRIPTION
## Summary
- create `python-forecast` FastAPI service
- document running the service and container

## Testing
- `python3 -m py_compile services/python-forecast/src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2f5fa19c832c8a9b00cc95379275