### PR TITLE
Add PHP ecommerce service

### DIFF
--- a/services/php-ecommerce/Dockerfile
+++ b/services/php-ecommerce/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.2-fpm-alpine
+WORKDIR /var/www/html
+COPY composer.json ./
+RUN apk add --no-cache git \
+    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');" \
+    && composer install --no-dev --prefer-dist \
+    && rm -rf /root/.composer
+COPY . .
+EXPOSE 3004
+CMD ["php", "-S", "0.0.0.0:3004", "-t", "src"]

--- a/services/php-ecommerce/README.md
+++ b/services/php-ecommerce/README.md
@@ -1,0 +1,30 @@
+# PHP E-commerce Service
+
+This service exposes simple catalog and cart endpoints using the Slim framework. It listens on **port 3004**.
+
+## Setup
+
+Install dependencies with Composer and start the development server:
+
+```bash
+cd services/php-ecommerce
+composer install
+php -S localhost:3004 -t src
+```
+
+The API will be available at `http://localhost:3004`.
+
+## Docker
+
+Build and run the container using the provided `Dockerfile` (based on an Alpine PHP-FPM image):
+
+```bash
+docker build -t php-ecommerce .
+docker run -p 3004:3004 php-ecommerce
+```
+
+## Endpoints
+
+- `GET /catalog` – list demo products
+- `GET /cart` – view current cart
+- `POST /cart` – add an item to the cart (`{ "item": "Product A" }`)

--- a/services/php-ecommerce/composer.json
+++ b/services/php-ecommerce/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "slim/slim": "^4.11",
+        "slim/psr7": "^1.6"
+    }
+}

--- a/services/php-ecommerce/src/index.php
+++ b/services/php-ecommerce/src/index.php
@@ -1,0 +1,46 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+session_start();
+
+$app = AppFactory::create();
+$app->addRoutingMiddleware();
+$errorMiddleware = $app->addErrorMiddleware(true, true, true);
+
+if (!isset($_SESSION['cart'])) {
+    $_SESSION['cart'] = [];
+}
+
+$app->get('/catalog', function (Request $request, Response $response) {
+    $catalog = [
+        ['id' => 1, 'name' => 'Product A'],
+        ['id' => 2, 'name' => 'Product B']
+    ];
+    $response->getBody()->write(json_encode($catalog));
+    return $response->withHeader('Content-Type', 'application/json');
+});
+
+$app->get('/cart', function (Request $request, Response $response) {
+    $response->getBody()->write(json_encode($_SESSION['cart']));
+    return $response->withHeader('Content-Type', 'application/json');
+});
+
+$app->post('/cart', function (Request $request, Response $response) {
+    $data = $request->getParsedBody();
+    if (isset($data['item'])) {
+        $_SESSION['cart'][] = $data['item'];
+    }
+    $response->getBody()->write(json_encode($_SESSION['cart']));
+    return $response->withHeader('Content-Type', 'application/json');
+});
+
+$app->get('/', function (Request $request, Response $response) {
+    $response->getBody()->write('E-commerce service running');
+    return $response;
+});
+
+$app->run();


### PR DESCRIPTION
## Summary
- add a PHP Slim-based ecommerce microservice
- provide Dockerfile using php:fpm-alpine
- document composer setup and container usage

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2f6730c4832c9a07fc69886f7485