### PR TITLE
Add Ruby CRM service

### DIFF
--- a/services/ruby-crm/Dockerfile
+++ b/services/ruby-crm/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:3.3-alpine
+WORKDIR /usr/src/app
+COPY Gemfile ./
+RUN bundle install --quiet
+COPY . .
+EXPOSE 3008
+CMD ["ruby", "app.rb"]

--- a/services/ruby-crm/Gemfile
+++ b/services/ruby-crm/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/services/ruby-crm/Gemfile.lock
+++ b/services/ruby-crm/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.3.0)
+    logger (1.7.0)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    ruby2_keywords (0.0.5)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.6.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  sinatra
+
+BUNDLED WITH
+   2.4.19

--- a/services/ruby-crm/README.md
+++ b/services/ruby-crm/README.md
@@ -1,0 +1,29 @@
+# Ruby CRM Service
+
+This service provides simple customer endpoints using Sinatra. It runs on port **3008**.
+
+## Setup
+
+Install the gems and start the server:
+
+```bash
+cd services/ruby-crm
+bundle install
+ruby app.rb
+```
+
+The server will listen on `http://localhost:3008`.
+
+## Docker
+
+Build and run the container:
+
+```bash
+docker build -t ruby-crm .
+docker run -p 3008:3008 ruby-crm
+```
+
+## Endpoints
+
+- `GET /customers` – returns a list of sample customers.
+- `GET /customers/:id` – returns a single customer by ID.

--- a/services/ruby-crm/app.rb
+++ b/services/ruby-crm/app.rb
@@ -1,0 +1,25 @@
+require 'sinatra'
+require 'json'
+
+set :port, ENV.fetch('PORT', 3008)
+
+CUSTOMERS = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' }
+]
+
+get '/customers' do
+  content_type :json
+  CUSTOMERS.to_json
+end
+
+get '/customers/:id' do
+  content_type :json
+  customer = CUSTOMERS.find { |c| c[:id] == params[:id].to_i }
+  halt 404, { error: 'Not found' }.to_json unless customer
+  customer.to_json
+end
+
+get '/' do
+  'CRM service running'
+end


### PR DESCRIPTION
## Summary
- add a new Ruby CRM service using Sinatra
- expose simple customer endpoints on port 3008
- include Dockerfile based on ruby:3.3-alpine
- document gem setup and container usage

## Testing
- `ruby -c app.rb`
- `bundle install`

------
https://chatgpt.com/codex/tasks/task_e_684c2f6c2180832c8ff9d5900a034683