### PR TITLE
Add Kotlin order service

### DIFF
--- a/services/kotlin-orders/Dockerfile
+++ b/services/kotlin-orders/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM gradle:8.4-jdk21-temurin AS build
+WORKDIR /workspace
+COPY . .
+RUN gradle installDist
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/build/install/kotlin-orders/ /app/
+EXPOSE 3010
+CMD ["./bin/kotlin-orders"]

--- a/services/kotlin-orders/README.md
+++ b/services/kotlin-orders/README.md
@@ -1,0 +1,39 @@
+# Kotlin Orders Service
+
+This service exposes simple endpoints for creating and listing sales orders. It uses the [Ktor](https://ktor.io/) framework and listens on **port 3010**.
+
+## Building
+
+Use Gradle to install the distribution:
+
+```bash
+cd services/kotlin-orders
+gradle installDist
+```
+
+The compiled distribution will be placed in `build/install/kotlin-orders/`.
+
+## Running Locally
+
+After building, run the service with the generated script:
+
+```bash
+build/install/kotlin-orders/bin/kotlin-orders
+```
+
+The service will start on `http://localhost:3010`.
+
+## Docker
+
+Build and run the container:
+
+```bash
+docker build -t kotlin-orders .
+docker run -p 3010:3010 kotlin-orders
+```
+
+## Endpoints
+
+- `GET /` – health check returning "Order service running".
+- `GET /orders` – list all orders.
+- `POST /orders` – create a new order using JSON body `{ "item": "name", "quantity": 1 }`.

--- a/services/kotlin-orders/build.gradle.kts
+++ b/services/kotlin-orders/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-core-jvm:2.3.7")
+    implementation("io.ktor:ktor-server-netty-jvm:2.3.7")
+    implementation("io.ktor:ktor-server-content-negotiation-jvm:2.3.7")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:2.3.7")
+    testImplementation("io.ktor:ktor-server-tests-jvm:2.3.7")
+    testImplementation(kotlin("test"))
+}
+
+application {
+    mainClass.set("com.example.orders.ApplicationKt")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/services/kotlin-orders/settings.gradle.kts
+++ b/services/kotlin-orders/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kotlin-orders"

--- a/services/kotlin-orders/src/main/kotlin/com/example/orders/Application.kt
+++ b/services/kotlin-orders/src/main/kotlin/com/example/orders/Application.kt
@@ -1,0 +1,51 @@
+package com.example.orders
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.Serializable
+import java.util.concurrent.atomic.AtomicInteger
+
+fun main() {
+    embeddedServer(
+        Netty,
+        port = System.getenv("PORT")?.toInt() ?: 3010,
+        module = Application::module
+    ).start(wait = true)
+}
+
+fun Application.module() {
+    install(ContentNegotiation) { json() }
+
+    val idCounter = AtomicInteger()
+    val orders = mutableListOf<Order>()
+
+    routing {
+        get("/") {
+            call.respondText("Order service running")
+        }
+
+        get("/orders") {
+            call.respond(orders)
+        }
+
+        post("/orders") {
+            val req = call.receive<OrderRequest>()
+            val order = Order(idCounter.incrementAndGet(), req.item, req.quantity)
+            orders.add(order)
+            call.respond(HttpStatusCode.Created, order)
+        }
+    }
+}
+
+@Serializable
+data class Order(val id: Int, val item: String, val quantity: Int)
+
+@Serializable
+data class OrderRequest(val item: String, val quantity: Int)


### PR DESCRIPTION
## Summary
- add `kotlin-orders` Ktor service running on port 3010
- provide Dockerfile and Gradle build
- document build and run instructions

## Testing
- `gradle --console=plain clean test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684c2f6f4d00832ca1275956d71ab50a