### PR TITLE
Add tools folder with sample headless services

### DIFF
--- a/tools/cms-strapi/Dockerfile
+++ b/tools/cms-strapi/Dockerfile
@@ -1,0 +1,3 @@
+FROM strapi/strapi
+
+EXPOSE 1337

--- a/tools/cms-strapi/README.md
+++ b/tools/cms-strapi/README.md
@@ -1,0 +1,15 @@
+# Strapi CMS
+
+This directory provides a simple Docker setup for running a Strapi headless CMS. The container exposes **port 1337**.
+
+## Docker
+
+Build and run the container:
+
+```bash
+cd tools/cms-strapi
+docker build -t cms-strapi .
+docker run -p 1337:1337 cms-strapi
+```
+
+The Strapi admin will be available at `http://localhost:1337/admin`.

--- a/tools/ecommerce-vendure/Dockerfile
+++ b/tools/ecommerce-vendure/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/vendure-ecommerce/vendure:latest
+
+EXPOSE 3050

--- a/tools/ecommerce-vendure/README.md
+++ b/tools/ecommerce-vendure/README.md
@@ -1,0 +1,15 @@
+# Vendure E-commerce Server
+
+Example container configuration for running Vendure in development mode. The application listens on **port 3050**.
+
+## Docker
+
+Build and run:
+
+```bash
+cd tools/ecommerce-vendure
+docker build -t ecommerce-vendure .
+docker run -p 3050:3050 ecommerce-vendure
+```
+
+After starting, access the admin UI at `http://localhost:3050/admin`.

--- a/tools/search-meilisearch/Dockerfile
+++ b/tools/search-meilisearch/Dockerfile
@@ -1,0 +1,3 @@
+FROM getmeili/meilisearch:v1.15.1
+
+EXPOSE 7700

--- a/tools/search-meilisearch/README.md
+++ b/tools/search-meilisearch/README.md
@@ -1,0 +1,15 @@
+# MeiliSearch Server
+
+This directory contains a Dockerfile for running the MeiliSearch search service. It exposes **port 7700**.
+
+## Docker
+
+Build and run:
+
+```bash
+cd tools/search-meilisearch
+docker build -t search-meilisearch .
+docker run -p 7700:7700 search-meilisearch
+```
+
+The service will be reachable at `http://localhost:7700`.


### PR DESCRIPTION
## Summary
- add `tools/` directory
- provide Strapi, Vendure, and MeiliSearch subfolders with Dockerfiles
- include simple READMEs describing how to run each tool

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c37b7579c832c85a0277ca8052966