### PR TITLE
Add host Dockerfile and docker-compose service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repository is linked to this article [MFE](https://dev.to/mairouche/setup-a
 The `host/` folder contains the Micro Frontend Shell with Vite Vanilla.
 The `apps/` folder contains the microfrontends modules (angular is not working at this stage but will be added in a later commit).
 
-Each of these folders is a standalone npm package with its own `package.json`. The repository root does not contain a `package.json`, so running npm commands from the root directory will fail. Make sure to run all npm scripts inside the relevant package folder (`apps/header`, `apps/trending` or `host`).
+Each of these folders is a standalone npm package with its own `package.json`. The repository root does **not** contain a `package.json`.
+
+> **Warning**
+> Running `npm` commands from the root directory will fail. Always navigate to the correct package folder (`apps/header`, `apps/trending` or `host`) before installing dependencies or running scripts.
 
 To start the application, follow the steps.
 
@@ -36,3 +39,18 @@ npm run dev
 ```
 
 Finally, you'll be able to see our micro frontend overall application on http://localhost:3000/
+
+---
+
+## Docker orchestration
+
+If you prefer to run the entire host inside a container, use the included Dockerfile and service in `docker-compose.yml`.
+
+```bash
+docker-compose up --build host
+```
+
+This command compiles `header`, `trending`, and the host in a multi-stage build, then serves the `dist` folder on port `3000`.
+
+> **Tip**
+> The development server uses port `5173` (see `host/vite.config.js`), but the Docker container exposes `3000` for consistency with the other services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,3 +68,9 @@ services:
     build: ./services/swift-notifications
     ports:
       - "3017:3017"
+  host:
+    build: ./host
+    ports:
+      - "3000:3000"
+    depends_on:
+      - node-notifications

--- a/host/Dockerfile
+++ b/host/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage: compile header, trending and host
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY apps/header/package*.json apps/header/
+COPY apps/trending/package*.json apps/trending/
+COPY host/package*.json host/
+RUN cd apps/header && npm ci && cd ..
+RUN cd apps/trending && npm ci && cd ..
+RUN cd host && npm ci && cd ..
+
+# Copy source code
+COPY apps apps
+COPY host host
+
+# Build microfrontends and host
+RUN cd apps/header && npm run build && cd ../..
+RUN cd apps/trending && npm run build && cd ../..
+RUN cd host && npm run build && cd ..
+
+# Runtime stage: serve the built host
+FROM node:22-alpine
+WORKDIR /app
+
+# Copy built host from builder stage
+COPY --from=builder /app/host/dist ./dist
+
+# Install lightweight static server
+RUN npm install -g serve
+
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]


### PR DESCRIPTION
## Summary
- automate host compilation using Dockerfile
- add host service to docker-compose
- expand README with warnings and orchestration instructions

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3a5b5130832cb8655706edac0953