### PR TITLE
Add ERP architecture scaffolding

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,12 @@
+name: Deploy Dev
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Docker Compose Up
+        run: docker compose -f deploy/docker-compose.core.yml -f deploy/docker-compose.services.yml up -d --build

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,0 +1,15 @@
+name: Deploy Prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://example.com
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy with Helm
+        run: echo "Helm deploy would run here"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [python-forecast, node-notifications]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build ${{ matrix.service }}
+        run: |
+          docker build -t ${{ matrix.service }} services/${{ matrix.service }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore Python caches
+**/__pycache__/
+# Ignore Node modules
+**/node_modules/
+# Ignore env files
+*.env

--- a/README.md
+++ b/README.md
@@ -54,3 +54,19 @@ This command compiles `header`, `trending`, and the host in a multi-stage build,
 
 > **Tip**
 > The development server uses port `5173` (see `host/vite.config.js`), but the Docker container exposes `3000` for consistency with the other services.
+
+## ERP Integration
+
+The repository now includes Docker compose files under `deploy/` for databases, services and tooling. Microservices live under `services/` while auxiliary containers (Keycloak, RabbitMQ, MLflow, etc.) are provided in `tools/`. A mapping of each service to its database can be found in `docs/databases-map.md`.
+
+CI workflows reside in `.github/workflows/` and a placeholder `apps/backend` directory has been added for future backend modules.
+
+### Running with Docker Compose
+
+To start core infrastructure and services locally:
+
+```bash
+docker compose -f deploy/docker-compose.core.yml -f deploy/docker-compose.services.yml up -d
+```
+
+Add `-f deploy/docker-compose.tools.yml` to include optional tooling such as Keycloak and Airflow.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,4 @@
+# Backend Microservices
+
+This directory mirrors the microservice set contained in `../../services`.
+Future backend services should live here to follow the ERP layout.

--- a/dbs/README.md
+++ b/dbs/README.md
@@ -1,0 +1,4 @@
+# Database Containers
+
+This directory contains lightweight images for various databases used by the micro ERP.
+Each subfolder exposes the default port for its database engine.

--- a/dbs/clickhouse/Dockerfile
+++ b/dbs/clickhouse/Dockerfile
@@ -1,0 +1,2 @@
+FROM clickhouse/clickhouse-server:22.9
+EXPOSE 9000 8123

--- a/dbs/mongo/Dockerfile
+++ b/dbs/mongo/Dockerfile
@@ -1,0 +1,2 @@
+FROM mongo:6
+EXPOSE 27017

--- a/dbs/mysql/Dockerfile
+++ b/dbs/mysql/Dockerfile
@@ -1,0 +1,2 @@
+FROM mysql:8
+EXPOSE 3306

--- a/dbs/postgres/Dockerfile
+++ b/dbs/postgres/Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres:15
+EXPOSE 5432

--- a/dbs/redis/Dockerfile
+++ b/dbs/redis/Dockerfile
@@ -1,0 +1,2 @@
+FROM redis:7
+EXPOSE 6379

--- a/deploy/docker-compose.core.yml
+++ b/deploy/docker-compose.core.yml
@@ -1,0 +1,74 @@
+version: '3.8'
+services:
+  postgres:
+    build: ../dbs/postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - ../dbs/volumes/postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: example
+
+  mongo:
+    build: ../dbs/mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - ../dbs/volumes/mongo:/data/db
+
+  mysql:
+    build: ../dbs/mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+    volumes:
+      - ../dbs/volumes/mysql:/var/lib/mysql
+
+  redis:
+    build: ../dbs/redis
+    ports:
+      - "6379:6379"
+
+  clickhouse:
+    build: ../dbs/clickhouse
+    ports:
+      - "9000:9000"
+      - "8123:8123"
+
+  rabbitmq:
+    build: ../tools/messaging-rabbitmq
+    ports:
+      - "5672:5672"
+
+  prometheus:
+    build: ../tools/observability/prometheus
+    ports:
+      - "9090:9090"
+
+  loki:
+    build: ../tools/observability/loki
+    ports:
+      - "3100:3100"
+
+  grafana:
+    build: ../tools/observability/grafana
+    ports:
+      - "3030:3000"
+
+  mlflow:
+    build: ../tools/mlflow
+    ports:
+      - "5000:5000"
+
+  minio:
+    build: ../tools/minio
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  airflow:
+    build: ../tools/airflow
+    ports:
+      - "8080:8080"

--- a/deploy/docker-compose.services.yml
+++ b/deploy/docker-compose.services.yml
@@ -1,0 +1,76 @@
+version: '3.8'
+services:
+  clojure-etl:
+    build: ../services/clojure-etl
+    ports:
+      - "3013:3013"
+  cpp-hardware:
+    build: ../services/cpp-hardware
+    ports:
+      - "3014:3014"
+  crystal-iot:
+    build: ../services/crystal-iot
+    ports:
+      - "3016:3016"
+  deno-functions:
+    build: ../services/deno-functions
+    ports:
+      - "3015:3015"
+  dotnet-identity:
+    build: ../services/dotnet-identity
+    ports:
+      - "3006:3006"
+  elixir-messaging:
+    build: ../services/elixir-messaging
+    ports:
+      - "3009:3009"
+  go-gateway:
+    build: ../services/go-gateway
+    ports:
+      - "3003:3003"
+  haskell-compliance:
+    build: ../services/haskell-compliance
+    ports:
+      - "3012:3012"
+  java-accounting:
+    build: ../services/java-accounting
+    ports:
+      - "3005:3005"
+  kotlin-orders:
+    build: ../services/kotlin-orders
+    ports:
+      - "3010:3010"
+  node-notifications:
+    build: ../services/node-notifications
+    ports:
+      - "3001:3001"
+  php-ecommerce:
+    build: ../services/php-ecommerce
+    ports:
+      - "3004:3004"
+  python-forecast:
+    build: ../services/python-forecast
+    ports:
+      - "3002:3002"
+  ruby-crm:
+    build: ../services/ruby-crm
+    ports:
+      - "3008:3008"
+  rust-analytics:
+    build: ../services/rust-analytics
+    ports:
+      - "3007:3007"
+  scala-reporting:
+    build: ../services/scala-reporting
+    ports:
+      - "3011:3011"
+  swift-notifications:
+    build: ../services/swift-notifications
+    ports:
+      - "3017:3017"
+  host:
+    build: ../host
+    ports:
+      - "3000:3000"
+    depends_on:
+      - node-notifications

--- a/deploy/docker-compose.tools.yml
+++ b/deploy/docker-compose.tools.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+services:
+  identity-keycloak:
+    build: ../tools/identity-keycloak
+    ports:
+      - "8080:8080"
+  messaging-rabbitmq:
+    build: ../tools/messaging-rabbitmq
+    ports:
+      - "5672:5672"
+  cms-strapi:
+    build: ../tools/cms-strapi
+    ports:
+      - "1337:1337"
+  ecommerce-vendure:
+    build: ../tools/ecommerce-vendure
+    ports:
+      - "3009:3009"
+  search-meilisearch:
+    build: ../tools/search-meilisearch
+    ports:
+      - "7700:7700"
+  workflow-camunda:
+    build: ../tools/workflow-camunda
+    ports:
+      - "8081:8080"
+  analytics-superset:
+    build: ../tools/analytics-superset
+    ports:
+      - "8088:8088"
+  mlflow:
+    build: ../tools/mlflow
+    ports:
+      - "5000:5000"
+  minio:
+    build: ../tools/minio
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+  airflow:
+    build: ../tools/airflow
+    ports:
+      - "8080:8080"
+  observability-prometheus:
+    build: ../tools/observability/prometheus
+    ports:
+      - "9090:9090"
+  observability-loki:
+    build: ../tools/observability/loki
+    ports:
+      - "3100:3100"
+  observability-grafana:
+    build: ../tools/observability/grafana
+    ports:
+      - "3030:3000"

--- a/docs/databases-map.md
+++ b/docs/databases-map.md
@@ -1,0 +1,18 @@
+# Service to Database Map
+
+| Service | Database | Notes |
+|---------|----------|-------|
+| auth-node | PostgreSQL | Row-level security for ACL |
+| sales-python | PostgreSQL + TimescaleDB | Accounting and sales time series |
+| inventory-go | MongoDB | Flexible product schemas |
+| crm-java | MySQL | Easy replication support |
+| billing-dotnet | SQL Server | Stored procedures for invoices |
+| analytics-rust | ClickHouse | Fast OLAP queries |
+| swift-notifications | Redis | Low latency pub/sub |
+| elixir-messaging | RabbitMQ | Persistent message queues |
+| go-gateway | Redis | Token cache and rate limiting |
+| python-forecast | PostgreSQL + MinIO | Predictions and datasets |
+| recommender | Neo4j | Graph recommendations |
+| vector-db | Qdrant/Weaviate | Semantic search |
+| feature-store | Feast (PostgreSQL + Redis) | Online features for ML |
+| observability | Prometheus + Loki | Metrics and logs |

--- a/services/node-notifications/.env.example
+++ b/services/node-notifications/.env.example
@@ -1,0 +1,2 @@
+DB_HOST=redis
+DB_PASS=secret

--- a/services/python-forecast/.env.example
+++ b/services/python-forecast/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=postgres
+DB_USER=svc_forecast
+DB_PASS=forecastpass
+MINIO_URL=http://minio:9000

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,3 @@
+# Tooling
+
+This directory contains auxiliary containers such as identity management, message brokers, observability stack, and ML pipelines.

--- a/tools/airflow/Dockerfile
+++ b/tools/airflow/Dockerfile
@@ -1,0 +1,2 @@
+FROM apache/airflow:2.7.1
+EXPOSE 8080

--- a/tools/airflow/README.md
+++ b/tools/airflow/README.md
@@ -1,0 +1,3 @@
+# Apache Airflow
+
+Container image for orchestrating ETL and ML pipelines.

--- a/tools/minio/Dockerfile
+++ b/tools/minio/Dockerfile
@@ -1,0 +1,2 @@
+FROM minio/minio:latest
+EXPOSE 9000

--- a/tools/minio/README.md
+++ b/tools/minio/README.md
@@ -1,0 +1,3 @@
+# MinIO
+
+Container image for object storage compatible with S3 APIs.

--- a/tools/mlflow/Dockerfile
+++ b/tools/mlflow/Dockerfile
@@ -1,0 +1,2 @@
+FROM mlflow/mlflow:latest
+EXPOSE 5000

--- a/tools/mlflow/README.md
+++ b/tools/mlflow/README.md
@@ -1,0 +1,3 @@
+# MLflow
+
+Container image for running an MLflow tracking server.

--- a/tools/observability/README.md
+++ b/tools/observability/README.md
@@ -1,0 +1,3 @@
+# Observability Stack
+
+This directory provides containers for Prometheus, Loki, and Grafana used to monitor the ERP platform.

--- a/tools/observability/grafana/Dockerfile
+++ b/tools/observability/grafana/Dockerfile
@@ -1,0 +1,2 @@
+FROM grafana/grafana:10.1.0
+EXPOSE 3000

--- a/tools/observability/grafana/provisioning/sample-dashboard.json
+++ b/tools/observability/grafana/provisioning/sample-dashboard.json
@@ -1,0 +1,6 @@
+{
+  "dashboard": {
+    "title": "Sample",
+    "panels": []
+  }
+}

--- a/tools/observability/loki/Dockerfile
+++ b/tools/observability/loki/Dockerfile
@@ -1,0 +1,2 @@
+FROM grafana/loki:2.8.2
+EXPOSE 3100

--- a/tools/observability/prometheus/Dockerfile
+++ b/tools/observability/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:latest
+EXPOSE 9090


### PR DESCRIPTION
## Summary
- add CI/CD workflows
- add database and tool Dockerfiles
- add deploy compose files for core services and tools
- document service to database mapping
- add sample env files and update README

## Testing
- `docker compose -f deploy/docker-compose.core.yml config` *(fails: `docker` not found)*
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684c54eb5a10832c9c6926978ab21026