### PR TITLE
Update scala reporting build

### DIFF
--- a/services/scala-reporting/Dockerfile
+++ b/services/scala-reporting/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:11.0.19_1.8.0_2.13.12 AS build
+FROM hseeberger/scala-sbt:11.0.14.1_1.6.2_2.13.8 AS build
 WORKDIR /app
 COPY build.sbt .
 RUN mkdir -p src/main/scala

--- a/services/scala-reporting/build.sbt
+++ b/services/scala-reporting/build.sbt
@@ -1,3 +1,3 @@
 name := "scala-reporting"
 version := "0.1.0"
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.8"


### PR DESCRIPTION
## Summary
- adjust the `scala-reporting` Dockerfile to use an available tag
- set the matching Scala version in `build.sbt`
- attempt to build the Docker image

## Testing
- `docker build -t scala-reporting-test .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c852c983c832ca31db46bfeaa4f63