### PR TITLE
Update gradle image tag for kotlin-orders

### DIFF
--- a/services/kotlin-orders/Dockerfile
+++ b/services/kotlin-orders/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM gradle:8.4-jdk21-temurin AS build
+FROM gradle:8-jdk21-ubi AS build
 WORKDIR /workspace
 COPY . .
 RUN gradle installDist


### PR DESCRIPTION
## Summary
- update `services/kotlin-orders/Dockerfile` to use the `gradle:8-jdk21-ubi` base image

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -t kotlin-orders-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684c852502e8832c8adf6a923e22be12