### PR TITLE
Switch to Compose v2 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This command compiles `header`, `trending`, and the host in a multi-stage build,
 
 The repository now includes Docker compose files under `deploy/` for databases, services and tooling. Microservices live under `services/` while auxiliary containers (Keycloak, RabbitMQ, MLflow, etc.) are provided in `tools/`. A mapping of each service to its database can be found in `docs/databases-map.md`.
 
+All Compose files now follow the Compose V2 schema and omit the top-level `version:` key.
+
 CI workflows reside in `.github/workflows/` and a placeholder `apps/backend` directory has been added for future backend modules.
 
 ### Running with Docker Compose

--- a/deploy/docker-compose.core.yml
+++ b/deploy/docker-compose.core.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     build: ../dbs/postgres

--- a/deploy/docker-compose.services.yml
+++ b/deploy/docker-compose.services.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clojure-etl:
     build: ../services/clojure-etl

--- a/deploy/docker-compose.tools.yml
+++ b/deploy/docker-compose.tools.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   identity-keycloak:
     build: ../tools/identity-keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clojure-etl:
     build: ./services/clojure-etl


### PR DESCRIPTION
## Summary
- drop deprecated `version:` key from all compose files
- note Compose v2 format in README

## Testing
- `python3 - <<'EOF'
import yaml
for f in ['docker-compose.yml','deploy/docker-compose.core.yml','deploy/docker-compose.services.yml','deploy/docker-compose.tools.yml']:
    with open(f) as fh:
        yaml.safe_load(fh)
print('validated')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684c853055ec832ca4f6e3e29de2428c